### PR TITLE
Fix typo in fetch command

### DIFF
--- a/docs/get_the_code.md
+++ b/docs/get_the_code.md
@@ -9,4 +9,4 @@
 (.bashrc와 같은 곳에 등록해두면 편합니다)
   - ```$ export PATH="$PATH:${HOME}/depot_tools"```
 - 원하는 위치에서(예: /home/zino/chromium), 소스코드를 다운로드합니다.
-  - ```$ fetch —no hooks chromium```
+  - ```$ fetch --nohooks chromium```


### PR DESCRIPTION
Fetch code in the guide
```
$ fetch --no hooks chromium
```
makes error below
```
Error: Invalid option --no.
usage: fetch.py [options] <config> [--property=value [--property2=value2 ...]]

This script can be used to download the Chromium sources. See
http://www.chromium.org/developers/how-tos/get-the-code
for full usage instructions.
```
Flag in command have to be `-nohooks`

Thank you